### PR TITLE
Update VTFLibOperators.py

### DIFF
--- a/Material_To_VTF/VTFLibOperators.py
+++ b/Material_To_VTF/VTFLibOperators.py
@@ -122,7 +122,7 @@ class vtf_operator(bpy.types.Operator):
         else:
             self.report({'INFO'}, "Starting material vtf conversion process...")
             command_line = list()
-            command_line.append(VTFLibCmdFilePath)
+            command_line.append("\"" + VTFLibCmdFilePath + "\"")
             
             # Get all materials and add to a args list
             # Requires cleanup later


### PR DESCRIPTION
Changed VTFCmd.exe execution to work with path names that included spaces and/or characters that might break the code execution. (Did not execute on my machine with spaces prior to this fix.)